### PR TITLE
Only set required if not `id` (creating a resource)

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -186,10 +186,15 @@ def make_schema(model, fields):
     if 'id' not in fields_def:
         fields_def['id'] = {'type': 'integer'}
     for field, attrs in fields_def.items():
-        required = attrs.get('required', False) and field not in defaults_fields
+        if 'id' not in fields:
+            required = (
+                attrs.get('required', False) and field not in defaults_fields
+            )
+        else:
+            required = False
         schema[field] = {
             'required': required,
-            'readonly': attrs.get('readonly', False)
+            'readonly': bool(attrs.get('readonly', False))
         }
         type_ = attrs['type']
         if type_ in ('text', 'char', 'selection'):


### PR DESCRIPTION
If we are creating a resource and a subdocument have the `id` key in this case we're linking or updating.. then we don't have to check the `required` fields.