### PR TITLE
ID key removal from "stored"

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -79,6 +79,8 @@ def recursive_crud(model, values):
         item_id = vals.pop('id', None)
         if vals:
             stored = model.read([item_id], list(vals.keys()))[0]
+            if 'id' in stored.keys():
+                stored.pop('id', None)
             for key, stored_value in stored.items():
                 if vals[key] == stored_value:
                     vals.pop(key)

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -79,8 +79,7 @@ def recursive_crud(model, values):
         item_id = vals.pop('id', None)
         if vals:
             stored = model.read([item_id], list(vals.keys()))[0]
-            if 'id' in stored.keys():
-                stored.pop('id', None)
+            stored.pop('id', None)
             for key, stored_value in stored.items():
                 if vals[key] == stored_value:
                     vals.pop(key)


### PR DESCRIPTION
This PR fixes an small bug that causes an exception when trying to make a patch call.

Example:

PATCH call URL: project.task.work/25
Body: {"name": "foobar"}

Without the fix, backend will raise an exception (id key not found).

With the fix, the task work with ID 25 is successfully patched.
