### PR TITLE
New URL to call model methods without a record

### DIFF
--- a/backend/backend_blueprint.py
+++ b/backend/backend_blueprint.py
@@ -5,7 +5,7 @@ import flask_restful as restful
 import flask_login as login
 from itsdangerous import JSONWebSignatureSerializer, BadSignature
 from backend.pool import Pool
-from backend.models import Model, ModelBunch, ModelMethod, Token
+from backend.models import Model, ModelBunch, ModelMethod, ModelIdMethod, Token
 import erppeek
 
 
@@ -16,7 +16,8 @@ api.init_app(backend)
 api.add_resource(Token, 'token')
 api.add_resource(ModelBunch, '<string:model>')
 api.add_resource(Model, '<string:model>/<int:id>')
-api.add_resource(ModelMethod, '<string:model>/<int:id>/<string:method>')
+api.add_resource(ModelIdMethod, '<string:model>/<int:id>/<string:method>')
+api.add_resource(ModelMethod, '<string:model>/<string:method>')
 
 login_manager = login.LoginManager()
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -166,6 +166,17 @@ class ModelBunch(BaseResource):
 
 
 class ModelMethod(BaseResource):
+    def post(self, model, method):
+        method = getattr(get_model(model), method)
+        data = request.json
+        if data and 'args' in data:
+            res = method(*data['args'])
+        else:
+            res = method()
+        return jsonify({'res': res})
+
+
+class ModelIdMethod(BaseResource):
     def post(self, model, id, method):
         model = get_model(model).browse(id)
         method = getattr(model, method)
@@ -175,3 +186,4 @@ class ModelMethod(BaseResource):
         else:
             res = method()
         return jsonify({'res': res})
+


### PR DESCRIPTION
This PR adds a new URL `/<model>/<method_name>` to call methods to a model without a `id` is useful to call fields like `fields_get`