### PR TITLE
Imp order at searches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ Optional arguments:
 * **schema**: List of fields you want in the JSON, you can use dots to deep browsing. (Default all fields of model)
 * **limit**: Number of maxim number of items. (Default 80)
 * **offset**: From which number to start. (Default 0)
+* **order**: Sort criteria string in SQL sintax, i.e 'id asc, name desc'. (Default empty sort criteria: '')
 
 The result is a json with the following keys:
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -176,8 +176,8 @@ class ModelBunch(BaseResource):
             type=int, help='Offset of results'
         )
         parser.add_argument(
-            'order', dest='order', default=0,
-            type=str, help='Results sort criteria in sql syntax'
+            'order', dest='order', default='',
+            type=str, help='Results sorting criteria in sql syntax'
         )
         args = parser.parse_args()
         limit = args.limit


### PR DESCRIPTION
Related to #29 it fixes the order initialization and updates the README with the new argument `order`

Fix #30 Add order parameter