### PR TITLE
Enable WS Transactions method

### DIFF
--- a/backend/pool.py
+++ b/backend/pool.py
@@ -1,7 +1,7 @@
 from hashlib import sha1
 from time import time
 
-from erppeek import Client
+from erppeek_wst import ClientWST as Client
 from six import text_type
 
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -241,13 +241,17 @@ def make_schema(model, fields):
 
 
 class WSTransaction(object):
+
+    def __init__(self):
+        self.errors = []
+
     def __enter__(self):
         self.client = g.backend_cnx
         self.transaction = self.client.begin()
         g.backend_cnx = self.transaction
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type:
+        if exc_type or self.errors:
             self.transaction.rollback()
         else:
             self.transaction.commit()

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -249,6 +249,7 @@ class WSTransaction(object):
         self.client = g.backend_cnx
         self.transaction = self.client.begin()
         g.backend_cnx = self.transaction
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type or self.errors:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask-restful
 Flask
 Erppeek
+ERPPeek-WST>=0.2.0
 osconf
 flask-login<0.3
 flask-cors


### PR DESCRIPTION
Now is possible to do all the things in the same transaction (PostgreSQL) if we have installed [ws_transactions](https://github.com/gisce/ws_transactions) installed in the ERP.

In the post method we have to do the following:

```python
from backend.utils import WSTransaction

def post()
    with WSTransaction() as trans:
        # Do all the stuff
		if something_is_wrong:
            trans.errors.append('Error 1')
        elif an_exception_is_raised:
           raise Exeption('Error')
    return "OK"
```

In both cases the transaction will be rolled back. The `errors` attribute of Transaction object is a simple list to store different errors.
