### PR TITLE
Solucionar problemas SSL

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,6 +6,19 @@ from __init__ import Backend
 from osconf import config_from_environment
 from raven.contrib.flask import Sentry
 
+try:
+    # Due: https://www.python.org/dev/peps/pep-0476
+    import ssl
+    try:
+        _create_unverified_https_context = ssl._create_unverified_context
+    except AttributeError:
+        # Legacy Python that doesn't verify HTTPS certificates by default
+        pass
+    else:
+        # Handle target environment that doesn't support HTTPS verification
+        ssl._create_default_https_context = _create_unverified_https_context
+except ImportError:
+    pass
 
 application = Flask(__name__)
 sentry = Sentry(application)


### PR DESCRIPTION
OBJECTIVES
Arrancar webgis con problemas de compatibilidad con ssl y versión de python.

OLD BEHAVIOR
Socket error genérico. 111 Connection rejected.

NEW BEHAVIOR
Añadido try except para arrancar con ssl.
